### PR TITLE
devfonks test

### DIFF
--- a/keyboard.c
+++ b/keyboard.c
@@ -17,6 +17,8 @@
 
 #include "keyboard.h"
 
+struct termios trm;
+
 void kb_enable()
 {
     tcgetattr(0, &trm);

--- a/keyboard.h
+++ b/keyboard.h
@@ -21,7 +21,7 @@
 #include <termios.h>
 #include <sys/ioctl.h>
 
-struct termios trm;
+extern struct termios trm;
 
 extern void kb_enable();
 extern void kb_disable();


### PR DESCRIPTION
I moved the definition of `struct termios trm` to keyboard.c and made an extern statement in keyboard.h to avoid every module built against kayboard.h having its own definition of trm. It was causing build problems as written and isn't good practice anyway. This way, trm is global as it seems was expected before this change.